### PR TITLE
Docker image for resumectl 🐳

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# Build-related files
+Dockerfile
+bin/
+
+# Unused files
+docs/
+
+# Generated files
+output
+*.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+
+# Build stage
+FROM golang:1.25-alpine3.23 AS builder
+WORKDIR /app
+
+RUN apk add --no-cache make
+COPY . .
+
+# Build the resumectl binary
+RUN go mod tidy
+RUN make build
+
+# Runtime stage
+FROM surnet/alpine-wkhtmltopdf:3.22.0-024b2b2-small
+WORKDIR /work
+
+# Copy the built binary
+COPY --from=builder /app/bin/resumectl /usr/local/bin/
+
+# Set the entrypoint to the resumectl tool
+# Display help as default command
+ENTRYPOINT ["resumectl"]
+CMD ["--help"]

--- a/README.md
+++ b/README.md
@@ -24,8 +24,12 @@ For reference, you can use the examples in `examples/`.
 ### Build
 
 ```bash
+# Build resumectl binary
 go mod tidy
 make build
+
+# Build resumectl Docker image
+docker build -t yourname/resumectl .
 ```
 
 ## Usage
@@ -100,6 +104,29 @@ resumectl themes
 # Live preview with hot reload
 resumectl serve
 ```
+
+### Docker
+
+Any of the previously listed commands can be run via Docker, using your built image
+
+```bash
+# Syntax
+docker run --rm -v $PWD:/work -u $(id -u):$(id -g) yourname/resumectl <command>
+
+# Examples
+docker run --rm -v $PWD:/work -u $(id -u):$(id -g) yourname/resumectl init
+docker run --rm -v $PWD:/work -u $(id -u):$(id -g) yourname/resumectl generate
+docker run --rm -v $PWD:/work -u $(id -u):$(id -g) -p 8080:8080 yourname/resumectl serve
+```
+
+<details>
+  <summary>Docker command breakdown</summary>
+
+  - `-v $PWD:/work` so the generated files end up in your current directory
+  - `-u $(id -u):$(id -g)` so the generated files get the proper permissions (!= root) in your filesystem
+  - `-p 8080:8080` to expose the preview webservice on http://localhost:8080
+  
+</details>
 
 ### Shell Completion
 


### PR DESCRIPTION
Hello there ! First of all, congratulations for making that amazing tool 🙌 

**Summary :**
I took the liberty to add a Dockerfile to build a Docker image for resumectl, and updated the README accordingly. I tried to keep it as light as possible, while keeping everything working well (especially PDF generation).

<img width="833" height="478" alt="image" src="https://github.com/user-attachments/assets/435cb295-d832-43ae-b03a-b765a621685c" />

**Additional idea :** 
It could be nice to add a simple Github Actions workflow to build an official image with each release, so people can simple use docker commands with `ghcr.io/juhnny5/resumectl` instead of having to build their own image

Feel free to edit what you want, or suggest me changes 😉

## Summary by Sourcery

Add Docker support for building and running resumectl and document Docker usage.

New Features:
- Introduce a Dockerfile to build a resumectl container image with PDF generation support.
- Allow running resumectl commands via Docker as an alternative to local installation.

Enhancements:
- Document Docker-based workflows in the README, including example commands and option breakdown.

Build:
- Add a Dockerfile and .dockerignore to support building a resumectl Docker image.